### PR TITLE
fixed transaction id prompt

### DIFF
--- a/client/src/pages/Transactions.js
+++ b/client/src/pages/Transactions.js
@@ -41,6 +41,7 @@ export default function Transactions() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    console.log(e.target.id); // e.target.id gives the id of the transaction PROBLEM SOLVED
     const tId = prompt("To confirm, please enter in the transaction ID you are updating")
     let tString
     tStatus === 'approve' ? tString = 'approved' : tString = 'rejected'
@@ -82,7 +83,7 @@ export default function Transactions() {
                           {
                             a.transactions.map(t => {
                               return (
-                                <ListItem>
+                                <ListItem key={t._id} id={t._id}>
                                   <div style={styles.name}>{u.firstName + " " + u.lastName}</div>
                                 <div>
                                   <ListItemText primary={"$ " + t.amount} secondary= {"To: " + t.transferTo + " Made on: " + t.createdAt} tertiary="test"/> 
@@ -111,7 +112,7 @@ export default function Transactions() {
                                         </Select>
                                       </FormControl>
                                     </div>
-                                    <Button variant="contained" onClick={handleSubmit} style={styles.button}>Change Transaction Status</Button>
+                                    <Button variant="contained" onClick={handleSubmit} style={styles.button} id={t._id}>Change Transaction Status</Button>
                                   </Box>
                                 </div>
                                 <Divider/>

--- a/server/schema/resolvers.js
+++ b/server/schema/resolvers.js
@@ -10,7 +10,7 @@ const { signToken } = require('../utils/auth');
 const resolvers = {
     Query: {
         getMe: async (parent, args, context) => {
-            const foundUser = await User.findOne({ _id: "63ed086c8d4ae45ae40d891d"}) // need to change to context.user._id in production
+            const foundUser = await User.findOne({ _id: "63eda74fe156442d98d345c8"}) // need to change to context.user._id in production
            
             if (!foundUser) {
               throw new AuthenticationError('Cannot find a user with this id!');


### PR DESCRIPTION
- Added transaction id's to id attribute for transactions list.
- Can now submit transaction approvals without prompt to ask for id.
- Need to figure out how to separate states for each transactions in the dropdown, option to create a function which can create each element with its own state, or create an array state, discuss later.